### PR TITLE
Configure manual trigger for backend pipeline

### DIFF
--- a/.github/workflows/platform-pipeline.yml
+++ b/.github/workflows/platform-pipeline.yml
@@ -12,6 +12,7 @@ on:
     branches: [ "main" ]
     paths: 
       - 'platform/**'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently we can't trigger workflow until a commit is pushed in /platform/ folder. After this change we will be able to manually trigger workflow.