### PR TITLE
Potential fix for code scanning alert no. 20: Database query built from user-controlled sources

### DIFF
--- a/react-fm/src/pages/matchQueues/AddPlayer.tsx
+++ b/react-fm/src/pages/matchQueues/AddPlayer.tsx
@@ -78,19 +78,26 @@ export const AddPlayer: FC<ChildProps> = ({
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          query: `mutation {
-          joinEvent(input: {
-                uniqueEventId: "${uniqueEventId}"
-                cityId: "${cityId}"
-                player: {
-                  waNumber: "${phoneNumber}"
-                  name: "${name}"
-                  teamColor: "${teamColor}"
+          query: `mutation joinEvent($uniqueEventId: String!, $cityId: String!, $waNumber: String!, $name: String!, $teamColor: String) {
+            joinEvent(input: {
+              uniqueEventId: $uniqueEventId
+              cityId: $cityId
+              player: {
+                waNumber: $waNumber
+                name: $name
+                teamColor: $teamColor
               }
-          }) {
-            isSuccessful
-          }
-      }`,
+            }) {
+              isSuccessful
+            }
+          }`,
+          variables: {
+            uniqueEventId,
+            cityId,
+            waNumber: phoneNumber,
+            name,
+            teamColor,
+          },
         }),
       })
         .then((response) => response.json())

--- a/react-fm/src/pages/matchQueues/eventsComponents/Events.tsx
+++ b/react-fm/src/pages/matchQueues/eventsComponents/Events.tsx
@@ -90,8 +90,8 @@ export const EventsCard: FC<EventDetails> = ({
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        query: `query City {
-        city(cityId: ${cityId}) {
+        query: `query City($cityId: ID!) {
+        city(cityId: $cityId) {
         cityId
         cityName
         localTimeZone
@@ -99,6 +99,9 @@ export const EventsCard: FC<EventDetails> = ({
         iconUrl
     }
   }`,
+        variables: {
+          cityId: cityId,
+        },
       }),
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/flickmatch/home/security/code-scanning/20](https://github.com/flickmatch/home/security/code-scanning/20)

To fix the problem, we need to ensure that the `cityId` is safely embedded into the GraphQL query. This can be achieved by using query variables instead of directly embedding the `cityId` into the query string. Query variables allow us to separate the query structure from the data, which helps in preventing injection attacks.

1. Modify the `currencyFromCity` function to use query variables for the `cityId`.
2. Update the `fetch` request to include the `variables` field in the request body.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
